### PR TITLE
make remoting work

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jvcts/config/ParserConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvcts/config/ParserConfig.java
@@ -7,17 +7,19 @@ import hudson.plugins.violations.TypeDescriptor;
 
 import com.google.common.base.Optional;
 
-public class ParserConfig {
+import java.io.Serializable;
+
+public class ParserConfig implements Serializable {
  private String pattern;
- private TypeDescriptor parserTypeDescriptor;
+ private String parserTypeDescriptorName;
  private String pathPrefix;
 
  public ParserConfig() {
 
  }
 
- public ParserConfig(TypeDescriptor typeDescriptor, String pattern) {
-  this.parserTypeDescriptor = typeDescriptor;
+ public ParserConfig(String typeDescriptorName, String pattern) {
+  this.parserTypeDescriptorName = typeDescriptorName;
   this.pattern = pattern;
  }
 
@@ -30,11 +32,15 @@ public class ParserConfig {
  }
 
  public TypeDescriptor getParserTypeDescriptor() {
-  return parserTypeDescriptor;
+  return TypeDescriptor.TYPES.get(parserTypeDescriptorName);
  }
 
- public void setParserTypeDescriptor(TypeDescriptor parser) {
-  this.parserTypeDescriptor = parser;
+ public String getParserTypeDescriptorName() {
+  return parserTypeDescriptorName;
+ }
+
+ public void setParserTypeDescriptorName(String name) {
+  this.parserTypeDescriptorName = name;
  }
 
  public void setPathPrefix(String pathPrefix) {

--- a/src/main/java/org/jenkinsci/plugins/jvcts/config/ViolationsToBitbucketServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvcts/config/ViolationsToBitbucketServerConfig.java
@@ -3,8 +3,9 @@ package org.jenkinsci.plugins.jvcts.config;
 import static com.google.common.collect.Lists.newArrayList;
 
 import java.util.List;
+import java.io.Serializable;
 
-public class ViolationsToBitbucketServerConfig {
+public class ViolationsToBitbucketServerConfig implements Serializable {
  private List<ParserConfig> parsers = newArrayList();
  private String bitbucketServerBaseUrl;
  private String bitbucketServerUser;

--- a/src/main/java/org/jenkinsci/plugins/jvcts/config/ViolationsToBitbucketServerConfigHelper.java
+++ b/src/main/java/org/jenkinsci/plugins/jvcts/config/ViolationsToBitbucketServerConfigHelper.java
@@ -35,9 +35,10 @@ public class ViolationsToBitbucketServerConfigHelper {
  public static ViolationsToBitbucketServerConfig createNewConfig() {
   ViolationsToBitbucketServerConfig config = new ViolationsToBitbucketServerConfig();
   List<ParserConfig> parsers = newArrayList();
-  for (TypeDescriptor parser : TypeDescriptor.TYPES.values()) {
+
+  for (String parser : TypeDescriptor.TYPES.keySet()) {
    ParserConfig parserConfig = new ParserConfig();
-   parserConfig.setParserTypeDescriptor(parser);
+   parserConfig.setParserTypeDescriptorName(parser);
    parsers.add(parserConfig);
   }
   config.setParsers(parsers);

--- a/src/test/java/org/jenkinsci/plugins/jvcts/perform/JvctsPerformerParseTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jvcts/perform/JvctsPerformerParseTest.java
@@ -8,7 +8,6 @@ import static java.nio.charset.Charset.defaultCharset;
 import static org.jenkinsci.plugins.jvcts.perform.JvctsPerformer.doPerform;
 import static org.jenkinsci.plugins.jvcts.utils.JvctsTestBuilder.assertThat;
 import static org.jenkinsci.plugins.jvcts.utils.JvctsTestUtils.assertRequested;
-import static org.jenkinsci.plugins.jvcts.utils.JvctsTestUtils.getWorkspace;
 import static org.jenkinsci.plugins.jvcts.utils.JvctsTestUtils.preConfigure;
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.CHANGES_GET;
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.COMMENTS_1_DELETE;
@@ -21,8 +20,11 @@ import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.fake;
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.prToCommit;
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.readFile;
 import hudson.model.StreamBuildListener;
+import hudson.FilePath;
 
 import java.io.IOException;
+
+import org.jenkinsci.plugins.jvcts.utils.JvctsTestUtils;
 
 import org.jenkinsci.plugins.jvcts.config.ParserConfig;
 import org.jenkinsci.plugins.jvcts.config.ViolationsToBitbucketServerConfig;
@@ -33,10 +35,10 @@ import com.google.common.collect.ImmutableList;
 public class JvctsPerformerParseTest {
 
  @Test
- public void testThatPullRequestCheckstyleIsCommented() throws IOException {
+ public void testThatPullRequestCheckstyleIsCommented() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(CHECKSTYLE), "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"))
+    new ParserConfig(CHECKSTYLE, "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"))
     .build());
   config.setBitbucketServerPullRequestId("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
@@ -57,12 +59,12 @@ public class JvctsPerformerParseTest {
  }
 
  @Test
- public void testThatPullRequestOldCommentsAreDeleted() throws IOException {
+ public void testThatPullRequestOldCommentsAreDeleted() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(PMD), "**/" + PMD + ".xml"),
-    new ParserConfig(TYPES.get(CHECKSTYLE), "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"),
-    new ParserConfig(TYPES.get(FINDBUGS), "**/" + FINDBUGS + ".xml")).build());
+    new ParserConfig(PMD, "**/" + PMD + ".xml"),
+    new ParserConfig(CHECKSTYLE, "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"),
+    new ParserConfig(FINDBUGS, "**/" + FINDBUGS + ".xml")).build());
   config.setBitbucketServerPullRequestId("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
   assertRequested(COMMENTS_CHECKSTYLEFILE_GET);
@@ -74,53 +76,57 @@ public class JvctsPerformerParseTest {
  }
 
  @Test
- public void testThatPullRequestCheckstyleAndPmdCanCommentsOnSameFileIsCommented() throws IOException {
+ public void testThatPullRequestCheckstyleAndPmdCanCommentsOnSameFileIsCommented() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   fake(
     "http://stash.server/rest/api/1.0/projects/stashProject/repos/stashRepo/pull-requests/1/comments?path=project/index.html&limit=999999 GET",
     readFile("pullrequestcomments_GET_none.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(PMD), "**/" + PMD + ".xml"),
-    new ParserConfig(TYPES.get(CHECKSTYLE), "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"),
-    new ParserConfig(TYPES.get(FINDBUGS), "**/" + FINDBUGS + ".xml")).build());
+    new ParserConfig(PMD, "**/" + PMD + ".xml"),
+    new ParserConfig(CHECKSTYLE, "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"),
+    new ParserConfig(FINDBUGS, "**/" + FINDBUGS + ".xml")).build());
   config.setBitbucketServerPullRequestId("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
   assertRequested(readFile("checkstyle_pmdandcheckstyle.json"));
  }
 
  @Test
- public void testThatPullRequestPmdIsCommented() throws IOException {
+ public void testThatPullRequestPmdIsCommented() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(PMD), "**/" + PMD + ".xml")).build());
+    new ParserConfig(PMD, "**/" + PMD + ".xml")).build());
   config.setBitbucketServerPullRequestId("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
   assertRequested(readFile("pmd_pmdfile.json"));
  }
 
  @Test
- public void testThatPullRequestFindbugsIsCommented() throws IOException {
+ public void testThatPullRequestFindbugsIsCommented() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(FINDBUGS), "**/" + FINDBUGS + ".xml")).build());
+    new ParserConfig(FINDBUGS, "**/" + FINDBUGS + ".xml")).build());
   config.setBitbucketServerPullRequestId("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
   assertRequested(readFile("findbugs_code.json"));
  }
 
  @Test
- public void testThatCommitCheckstyleIsCommented() throws IOException {
+ public void testThatCommitCheckstyleIsCommented() throws IOException, InterruptedException {
   fake(CHANGES_GET, readFile("pullrequestchanges_1_GET.json"));
   fake(
     "http://stash.server/rest/api/1.0/projects/stashProject/repos/stashRepo/pull-requests/1/comments?path=project/index.html&limit=999999 GET",
     readFile("pullrequestcomments_GET_none.json"));
   ViolationsToBitbucketServerConfig config = preConfigure(new ImmutableList.Builder<ParserConfig>().add(
-    new ParserConfig(TYPES.get(CHECKSTYLE), "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"))
+    new ParserConfig(CHECKSTYLE, "**/" + CHECKSTYLE + ".xml, **/" + CHECKSTYLE + "_relativePath.xml"))
     .build());
   config.setCommitHash("1");
   doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
   assertRequested(prToCommit(readFile("checkstyle_checkstylefile_1.json")));
   assertRequested(prToCommit(readFile("checkstyle_checkstylefile_2.json")));
   assertRequested(prToCommit(readFile("checkstyle_checkstylefile_3_relativePath.json")));
+ }
+
+ private FilePath getWorkspace() {
+   return new FilePath(JvctsTestUtils.getWorkspace());
  }
 }

--- a/src/test/java/org/jenkinsci/plugins/jvcts/utils/JvctsTestBuilder.java
+++ b/src/test/java/org/jenkinsci/plugins/jvcts/utils/JvctsTestBuilder.java
@@ -12,6 +12,7 @@ import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.CHANG
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.fake;
 import static org.jenkinsci.plugins.jvcts.utils.BitbucketServerClientFaker.readFile;
 import hudson.model.StreamBuildListener;
+import hudson.FilePath;
 
 import java.util.List;
 import java.util.Map;
@@ -43,11 +44,11 @@ public class JvctsTestBuilder {
  public void test() throws Exception {
   List<ParserConfig> configs = newArrayList();
   for (String pattern : patternsPerType.keySet()) {
-   configs.add(new ParserConfig(TYPES.get(pattern), patternsPerType.get(pattern)));
+   configs.add(new ParserConfig(pattern, patternsPerType.get(pattern)));
   }
   ViolationsToBitbucketServerConfig config = preConfigure(configs);
   config.setBitbucketServerPullRequestId("1");
-  doPerform(config, getWorkspace(), new StreamBuildListener(System.out, defaultCharset()));
+  doPerform(config, new FilePath(getWorkspace()), new StreamBuildListener(System.out, defaultCharset()));
   for (String asserted : assertRequested) {
    assertRequested(asserted);
   }


### PR DESCRIPTION
Requires hudson.plugins.violations.model.Violation to implement Serializable.

I can
- try to push pash to *violation-plugin*, or
- add commit, which implements custom `Violation` class for data transfer across channel.

Please let me know, what would you like to rather do.

Some pieces are modified parts from *violation-plugin*.

Tested on my private Jenkins instance.