### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 #!groovy
 
-buildPlugin(jdkVersions: [7, 8])
+buildPlugin()


### PR DESCRIPTION
Jenkins and recent parent POM only builds against Java 8
https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md#31
https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildPlugin.groovy#L8
https://github.com/jenkins-infra/pipeline-library/pull/2