### PR TITLE
Add support for automatic Bitbucket server endpoint configuration by utilizing the Jenkins job configuration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,21 @@ Changelog of Violation Comments to Bitbucket Server Plugin.
 		</plugins>
 	</build>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.jcraft</groupId>
+				<artifactId>jsch</artifactId>
+				<version>0.1.53</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>credentials</artifactId>
-			<version>2.1.4</version>
+			<version>2.1.13</version>
 		</dependency>
 		<dependency>
 			<groupId>se.bjurr.violations</groupId>
@@ -197,6 +207,11 @@ Changelog of Violation Comments to Bitbucket Server Plugin.
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>plain-credentials</artifactId>
 			<version>1.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>cloudbees-bitbucket-branch-source</artifactId>
+			<version>2.2.0</version>
 		</dependency>
 
 		<!-- test // -->

--- a/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerGlobalConfiguration.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.jvctb.config.CredentialsHelper;
+import org.jenkinsci.plugins.jvctb.config.ViolationsToBitbucketServerConfig;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -84,6 +85,16 @@ public class ViolationsToBitbucketServerGlobalConfiguration extends GlobalConfig
       @QueryParameter String value,
       @QueryParameter String bitbucketServerUrl) {
     return CredentialsHelper.doCheckFillCredentialsId(item, value, bitbucketServerUrl);
+  }
+
+  public ViolationsToBitbucketServerConfig getConfig() {
+    final ViolationsToBitbucketServerConfig config = new ViolationsToBitbucketServerConfig();
+    config.setBitbucketServerUrl(bitbucketServerUrl);
+    config.setCredentialsId(credentialsId);
+    config.setProjectKey(projectKey);
+    config.setRepoSlug(repoSlug);
+
+    return config;
   }
 
   public String getBitbucketServerUrl() {

--- a/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerJobConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerJobConfiguration.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.jvctb;
+
+import java.io.Serializable;
+
+import org.jenkinsci.plugins.jvctb.config.ViolationsToBitbucketServerConfig;
+
+import com.cloudbees.jenkins.plugins.bitbucket.BitbucketSCMSource;
+import com.cloudbees.jenkins.plugins.bitbucket.PullRequestSCMHead;
+import com.google.common.base.Optional;
+
+import hudson.model.Job;
+import hudson.model.Run;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+
+public class ViolationsToBitbucketServerJobConfiguration implements Serializable {
+
+  public static Optional<ViolationsToBitbucketServerConfig> getConfig(final Run<?, ?> buildRun) {
+    final Job<?, ?> buildJob = buildRun.getParent();
+
+    final SCMSource jobScmSource = SCMSource.SourceByItem.findSource(buildJob);
+    if (!(jobScmSource instanceof BitbucketSCMSource)) {
+      return Optional.absent();
+    }
+
+    final SCMHead jobScmHead = SCMHead.HeadByItem.findHead(buildJob);
+    if (!(jobScmHead instanceof PullRequestSCMHead)) {
+      return Optional.absent();
+    }
+
+    final BitbucketSCMSource bitbucketScmSource = (BitbucketSCMSource) jobScmSource;
+    final PullRequestSCMHead pullRequestScmHead = (PullRequestSCMHead) jobScmHead;
+
+    final ViolationsToBitbucketServerConfig config = new ViolationsToBitbucketServerConfig();
+    config.setBitbucketServerUrl(bitbucketScmSource.getServerUrl());
+    config.setCredentialsId(bitbucketScmSource.getCredentialsId());
+    config.setProjectKey(pullRequestScmHead.getRepoOwner());
+    config.setRepoSlug(pullRequestScmHead.getRepository());
+    config.setPullRequestId(pullRequestScmHead.getId());
+
+    return Optional.of(config);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctb/ViolationsToBitbucketServerRecorder.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import org.jenkinsci.plugins.jvctb.config.ViolationsToBitbucketServerConfig;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import com.google.common.base.Optional;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -57,11 +59,19 @@ public class ViolationsToBitbucketServerRecorder extends Recorder implements Sim
 
     ViolationsToBitbucketServerConfig combinedConfig =
         new ViolationsToBitbucketServerConfig(this.config);
-    ViolationsToBitbucketServerGlobalConfiguration defaults =
-        ViolationsToBitbucketServerGlobalConfiguration.get()
-            .or(new ViolationsToBitbucketServerGlobalConfiguration());
 
-    combinedConfig.applyDefaults(defaults);
+    ViolationsToBitbucketServerConfig defaults =
+        ViolationsToBitbucketServerGlobalConfiguration.get()
+            .or(new ViolationsToBitbucketServerGlobalConfiguration())
+            .getConfig();
+
+    combinedConfig.apply(defaults);
+
+    Optional<ViolationsToBitbucketServerConfig> jobConfig =
+        ViolationsToBitbucketServerJobConfiguration.getConfig(build);
+    if (jobConfig.isPresent()) {
+      combinedConfig.apply(jobConfig.get());
+    }
 
     jvctsPerform(combinedConfig, filePath, build, listener);
   }

--- a/src/main/java/org/jenkinsci/plugins/jvctb/config/ViolationsToBitbucketServerConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/jvctb/config/ViolationsToBitbucketServerConfig.java
@@ -8,7 +8,6 @@ import java.io.Serializable;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.jvctb.ViolationsToBitbucketServerGlobalConfiguration;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
@@ -71,21 +70,24 @@ public class ViolationsToBitbucketServerConfig
     this.keepOldComments = rhs.keepOldComments;
   }
 
-  public void applyDefaults(final ViolationsToBitbucketServerGlobalConfiguration defaults) {
+  public void apply(final ViolationsToBitbucketServerConfig config) {
     if (isNullOrEmpty(bitbucketServerUrl)) {
-      bitbucketServerUrl = defaults.getBitbucketServerUrl();
+      bitbucketServerUrl = config.getBitbucketServerUrl();
     }
     if (isNullOrEmpty(credentialsId)) {
-      credentialsId = defaults.getCredentialsId();
+      credentialsId = config.getCredentialsId();
     }
     if (isNullOrEmpty(repoSlug)) {
-      repoSlug = defaults.getRepoSlug();
+      repoSlug = config.getRepoSlug();
     }
     if (isNullOrEmpty(projectKey)) {
-      projectKey = defaults.getProjectKey();
+      projectKey = config.getProjectKey();
+    }
+    if (isNullOrEmpty(pullRequestId)) {
+      pullRequestId = config.getPullRequestId();
     }
     if (this.minSeverity == null) {
-      this.minSeverity = defaults.getMinSeverity();
+      this.minSeverity = config.getMinSeverity();
     }
   }
 


### PR DESCRIPTION
Currently the server url, credentials ID, repository name, project key and pull request ID have to be provided either by setting them statically in the (global) Jenkins configuration or by providing them as job parameters.

If the Jenkins item is of type "Bitbucket git repository" or "Bitbucket Team/Project" these values are already configured in Jenkins and accessible via the standard Bitbucket integration. This way the configuration of the mentioned parameters would not be necessary.
